### PR TITLE
Handle new cores.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -81,9 +81,46 @@ internal class Program
             await updater.Initialize();
 
             if(coreSelector || settings.GetConfig().core_selector) {
+                settings.EnableMissingCores(updater.GetMissingCores());
                 List<Core> cores =  await CoresService.GetCores();
+                AskAboutNewCores(settings, true);
                 RunCoreSelector(settings, cores);
                 updater.LoadSettings();
+            }
+
+            // If we have any missing cores, handle them.
+            if(updater.GetMissingCores().Any()) {
+                Console.WriteLine("\nNew cores found since the last run.");
+                AskAboutNewCores(settings);
+
+                string? download_new_cores = settings.GetConfig().download_new_cores?.ToLowerInvariant();
+                switch (download_new_cores) {
+                    case "yes":
+                        Console.WriteLine("The following cores have been enabled:");
+                        foreach(Core core in updater.GetMissingCores())
+                            Console.WriteLine($"- {core.identifier}");
+
+                        settings.EnableMissingCores(updater.GetMissingCores());
+                        settings.SaveSettings();
+                        Console.WriteLine("Press ENTER to continue.");
+                        Pause();
+                        break;
+                    case "no":
+                        Console.WriteLine("The following cores have been disabled:");
+                        foreach(Core core in updater.GetMissingCores())
+                            Console.WriteLine($"- {core.identifier}");
+
+                        settings.DisableMissingCores(updater.GetMissingCores());
+                        settings.SaveSettings();
+                        Console.WriteLine("\nPress ENTER to continue.");
+                        Pause();
+                        break;
+                    default:
+                    case "ask":
+                        RunCoreSelector(settings, updater.GetMissingCores());
+                        settings.ClearNewCores();
+                        break;
+                }
             }
 
             if(!forceUpdate) {
@@ -98,8 +135,11 @@ internal class Program
                             break;
                         case 2:
                             List<Core> cores =  await CoresService.GetCores();
+                            AskAboutNewCores(settings, true);
                             RunCoreSelector(settings, cores);
                             updater.LoadSettings();
+
+                            Console.WriteLine("\nDone!  Press ENTER to continue.");
                             Pause();
                             break;
                         case 3:
@@ -130,17 +170,22 @@ internal class Program
 
     static void RunCoreSelector(SettingsManager settings, List<Core> cores)
     {
-        ConsoleKey response;
-        Console.WriteLine("\nSelect your cores! The available cores will be listed 1 at a time. For each one, hit 'n' if you don't want it installed, or just hit enter if you want it. Ok you've got this. Here we go...\n");
-        foreach(Core core in cores) {
-            Console.Write(core.identifier + "?[Y/n] ");
-            response = Console.ReadKey(false).Key;
-            if (response == ConsoleKey.N) {
-                settings.DisableCore(core.identifier);
-            } else {
+        if(settings.GetConfig().download_new_cores?.ToLowerInvariant() == "yes") {
+            foreach(Core core in cores)
                 settings.EnableCore(core.identifier);
+        } else {
+            ConsoleKey response;
+            Console.WriteLine("\nSelect your cores! The available cores will be listed 1 at a time. For each one, hit 'n' if you don't want it installed, or just hit enter if you want it. Ok you've got this. Here we go...\n");
+            foreach(Core core in cores) {
+                Console.Write(core.identifier + "?[Y/n] ");
+                response = Console.ReadKey(false).Key;
+                if (response == ConsoleKey.N) {
+                    settings.DisableCore(core.identifier);
+                } else {
+                    settings.EnableCore(core.identifier);
+                }
+                Console.WriteLine("");
             }
-            Console.WriteLine("");
         }
         settings.GetConfig().core_selector = false;
         settings.SaveSettings();
@@ -292,6 +337,23 @@ internal class Program
     private static void Pause()
     {
         Console.ReadLine();
+    }
+
+    private static void AskAboutNewCores(SettingsManager settings, bool force = false)
+    {
+        while(settings.GetConfig().download_new_cores == null || force) {
+            force = false;
+
+            Console.WriteLine("Would you like to download all available cores? [Y]es, [N]o, [A]sk for each:");
+            ConsoleKey response = Console.ReadKey(false).Key;
+            settings.GetConfig().download_new_cores = response switch
+            {
+                ConsoleKey.Y => "yes",
+                ConsoleKey.N => "no",
+                ConsoleKey.A => "ask",
+                _ => null
+            };
+        }
     }
 
     private static string[] menuItems = {

--- a/SettingsManager.cs
+++ b/SettingsManager.cs
@@ -8,6 +8,7 @@ public class SettingsManager
 {
     private Settings _settings;
     private string _settingsFile;
+    private List<Core> _newCores = new();
 
     private const string OLD_DEFAULT = "pocket-roms";
     private const string NEW_DEFAULT = "openFPGA-Files";
@@ -51,10 +52,24 @@ public class SettingsManager
         foreach(Core core in cores)
         {
             if(!_settings.coreSettings.ContainsKey(core.identifier)) {
-                EnableCore(core.identifier);
+                _newCores.Add(core);
+                //EnableCore(core.identifier);
             }
         }
     }
+
+    public List<Core> GetMissingCores() => _newCores;
+    public void EnableMissingCores(List<Core> cores)
+    {
+        foreach (var core in cores)
+            EnableCore(core.identifier);
+    }
+    public void DisableMissingCores(List<Core> cores)
+    {
+        foreach (var core in cores)
+            DisableCore(core.identifier);
+    }
+    public void ClearNewCores() => _newCores.Clear();
 
     public bool SaveSettings()
     {

--- a/Updater.cs
+++ b/Updater.cs
@@ -39,6 +39,7 @@ public class PocketCoreUpdater : Base
     private List<Core>? _cores;
 
     private Dictionary<string, Dependency>? _assets;
+
     /// <summary>
     /// Constructor
     /// </summary>
@@ -85,6 +86,8 @@ public class PocketCoreUpdater : Base
     {
          _settingsManager = new SettingsManager(SettingsPath, _cores);
     }
+
+    public List<Core> GetMissingCores() => _settingsManager?.GetMissingCores() ?? new List<Core>();
 
     /// <summary>
     /// Turn on/off printing progress messages to the console

--- a/models/Settings/Config.cs
+++ b/models/Settings/Config.cs
@@ -9,6 +9,7 @@ public class Config
     public bool core_selector { get; set; }
     public bool preserve_platforms_folder { get; set; }
     public bool delete_skipped_cores { get; set; }
+    public string? download_new_cores { get; set; }
 
     public Config()
     {
@@ -18,5 +19,6 @@ public class Config
         core_selector = true;
         preserve_platforms_folder = false;
         delete_skipped_cores = true;
+        download_new_cores = null;
     }
 }


### PR DESCRIPTION
Added a new config option named "download_new_cores" to control how new cores are handled.  Accepted values are "yes", "no", and "ask".  Run the core selector to change this option.

This will close #59.