### PR TITLE
Add support for in-place auto update

### DIFF
--- a/pocket_updater.csproj
+++ b/pocket_updater.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.9.2</Version>
+    <Version>2.9.3</Version>
     <Description>Keep your Analogue Pocket up to date</Description>
     <Copyright>2022 Matt Pannella</Copyright>
     <Authors>Matt Pannella</Authors>


### PR DESCRIPTION
Basically, rename the current executable, grab the updated one from the zip, and run it.
On Windows, we can terminate the parent immediately and the child deletes the old exe when it checks for updates again. On Linux (and maybe macos), this somehow disconnects stdin, so on Linux/Mac we need to have the parent wait for the child to finish before exiting. But with how filesystems work on *nix, they're fine to delete the old exe even though it's still running. Windows will let you rename a running executable, but not delete it.

Tested on Win11, Linux (Ubuntu 20.04) and macOS 10.15. I probably didn't build it quite the same way as the official release, though, so a smoketest on Win10/Linux/macOS would be appreciated.