### PR TITLE
Automatically create the Cores and parent directories

### DIFF
--- a/Updater.cs
+++ b/Updater.cs
@@ -47,6 +47,7 @@ public class PocketCoreUpdater : Base
     public PocketCoreUpdater(string updateDirectory, string? settingsPath = null)
     {
         UpdateDirectory = updateDirectory;
+        Directory.CreateDirectory(Path.Combine(UpdateDirectory, "Cores"));
 
         if(settingsPath != null) {
             SettingsPath = settingsPath;


### PR DESCRIPTION
This change fixes two errors that might occur when running `pocket_updater` on a clean directory that does not have the `Cores` directory - either by running it with no parameters or specifying a custom path with the `--path` parameter:

```
$ ./pocket_updater --path /tmp/pocket-updater
Could not find a part of the path '/tmp/pocket-updater/pocket_updater_settings.json'.
``` 

```
$ ./pocket_updater
...
Choose your destiny: 0
Starting update process...
Checking for firmware updates...
Firmware up to date.
-------------
Well, something went wrong. Sorry about that.
Could not find a part of the path '/home/knorrium/dev/clones/pocket-updater-utility/bin/Debug/net6.0/Cores'.
``` 

Tested only on Linux.