### PR TITLE
Windows path fix for json builder

### DIFF
--- a/models/Core.cs
+++ b/models/Core.cs
@@ -389,7 +389,7 @@ public class Core : Base
             Analogue.SimpleInstance instance = new Analogue.SimpleInstance();
             string dirName = Path.GetFileName(dir);
             try {
-                instance.data_path = dir.Replace(commonPath + "/", "") + "/";
+                instance.data_path = dir.Replace(commonPath + Path.DirectorySeparatorChar, "") + "/";
                 List<Analogue.InstanceDataSlot> slots = new List<Analogue.InstanceDataSlot>();
                 string jsonFileName = dirName + ".json";
                 foreach(DataSlot slot in packager.data_slots) {

--- a/pocket_updater.csproj
+++ b/pocket_updater.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>2.16.1</Version>
+    <Version>2.16.2</Version>
     <Description>Keep your Analogue Pocket up to date</Description>
     <Copyright>2023 Matt Pannella</Copyright>
     <Authors>Matt Pannella</Authors>


### PR DESCRIPTION
data_path wasn't being properly set when building instance jsons. 