### PR TITLE
Changed error message that is not always true.

### DIFF
--- a/src/models/Core.cs
+++ b/src/models/Core.cs
@@ -199,7 +199,7 @@ public class Core : Base
                         }
                     }
                 } catch (Exception e) {
-                    _writeMessage("Unable to read " + file);
+                    _writeMessage("Error while processing " + file);
                     _writeMessage(e.Message);
                 }
             }


### PR DESCRIPTION
When I got this error in the first time I was very confused, thinking that is something wrong with my JSONs and spend about an hour checking internal data format and file permissions before I even realise, that it was a timeout cancel. So I suggest to change it to be more clear.

<img width="602" alt="Screenshot 2023-03-27 at 14 10 57" src="https://user-images.githubusercontent.com/6708914/227926860-ea6081a4-526f-465d-9bb3-986973260c3b.png">
