### PR TITLE
Updated Image Packs with dyreschlock regional alts

### DIFF
--- a/image_packs.json
+++ b/image_packs.json
@@ -6,12 +6,22 @@
     {
         "owner": "dyreschlock",
         "repository": "pocket-platform-images",
+        "variant": "arcade"
+    },
+    {
+        "owner": "dyreschlock",
+        "repository": "pocket-platform-images",
         "variant": "home"
     },
     {
         "owner": "dyreschlock",
         "repository": "pocket-platform-images",
-        "variant": "arcade"
+        "variant": "home_jp_alts"
+    },
+    {
+        "owner": "dyreschlock",
+        "repository": "pocket-platform-images",
+        "variant": "home_pal_alts"
     },
     {
         "owner": "terminator2k2",


### PR DESCRIPTION
I made a new release of my Image Pack that includes 2 new zips, `home_jp_alts` and `home_pal_alts`. I included them in your image packs list.